### PR TITLE
Fixing line item controller spec

### DIFF
--- a/spec/controllers/spree/api/line_items_controller_spec.rb
+++ b/spec/controllers/spree/api/line_items_controller_spec.rb
@@ -22,7 +22,8 @@ module Spree
       context "as a line item is updated" do
         it "update distribution charge on the order" do
           line_item_params = { order_id: order.number, id: line_item.id, line_item: { id: line_item.id, unit_value: 520 }, format: :json}
-          order.should_receive(:update_distribution_charge!).and_call_original
+          allow(controller).to receive(:order) { order }
+          expect(order).to receive(:update_distribution_charge!)
           spree_post :update, line_item_params
         end
       end


### PR DESCRIPTION
Yo,

Looking good! Nice work, the migration and logic around copying unit values across look perfect to me.

So the problem here was that order we were dealing with in the spec is a different instance to the one we are dealing with in the controller itself. Therefore, when update_distribution_charge! is called on the order in the controller, the watcher defined in the spec doesn't pick it up because it is watching a different object. My bad, I should have picked that up.

Stubs to the rescue! We know that the controller calls #order, to fetch the relevant order from the database based on the submitted order number (this is in the original controller defined in the spree repository). So we can stub this method out (line 25) and ask that method to instead return the instance that we want, ie. the instance that we created in the spec, and the one we are putting an expect clause on.

Then when we put the expect clause (line 26), we are using the same instance of order, and the spec passes. NOTE: line 26 does the exact same thing as your original stub, but this is the new RSpec syntax.

Hope that helps.

One final issue that I am having is when there is no unit_value present on the variant and this is copied across to the line_item. When this happens, the logic on the BOM page still does not handle changing that unit_value from zero to any other number very well, I get a plank price which I cannot change back, and then I get an error (red border) when I attempt to submit the blank price. Can I suggest that the unit_value field is disabled or replaced with an input which just says N/A or something when unit unit_value is zero?